### PR TITLE
✨ expose AuthContext so it can be mocked in unit tests

### DIFF
--- a/src/components/Auth/index.ts
+++ b/src/components/Auth/index.ts
@@ -1,2 +1,2 @@
-export { useLoginContext, AuthProvider } from './AuthProvider';
+export { useLoginContext, AuthProvider, AuthContext } from './AuthProvider';
 export { default as AuthGuard } from './AuthGuard';


### PR DESCRIPTION
For unit or Cypress tests, we usually want to disable the application login completely to avoid requests to external systems.

The easiest way to accomplish this is by overriding the `AuthContext` and providing mock state and login methods. This way, no other changes to the application code are required.