### PR TITLE
✨ allow passing additional extra parameters with login and logout calls

### DIFF
--- a/src/hooks/Auth.ts
+++ b/src/hooks/Auth.ts
@@ -35,7 +35,7 @@ export interface AuthenticateOptions {
 }
 
 export interface AuthState {
-  login: () => Promise<void>;
+  login: (authorizationRequest?: AuthenticateOptions['authorizationRequest']) => Promise<void>;
   logout: () => Promise<boolean | undefined>;
   token?: string;
   idToken?: string;


### PR DESCRIPTION
For use cases like registration or custom login prompts, it can be useful to pass additional parameters with the login call instead of configuring them globally on the provider.

For compatibility, I used the options types from the `AuthenticateOptions` interface and added them to the `login` and `logout` calls. The `extras` properties are merged, local parameters overriding configuration values.

Example:
```js
login({ extras: { id_token_hint: 'ID_TOKEN' } })
```