### PR TITLE
🔧 set typescript target to es5 to support IE11

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es5", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "strict": true, /* Enable all strict type-checking options. */


### PR DESCRIPTION
As the base `appauth` library also targets ES5, we should set the same compile target to support legacy browsers like IE11.

This does not prevent us from using advanced ES features as the code is transpiled and IE11 users can polyfill the required functions.