### PR TITLE
✨ Revoke token if endSessionEndpoint is not available, expose looaded…

### DIFF
--- a/src/appauth/redirectEndSessionRequestHandler.ts
+++ b/src/appauth/redirectEndSessionRequestHandler.ts
@@ -43,9 +43,13 @@ export class RedirectEndSessionRequestHandler extends EndSessionRequestHandler {
     // before you make request, clear the storage.
     void this.storageBackend.clear().then(() => {
       // make the redirect request
-      const url = this.buildRequestUrl(configuration, request);
-      log('Making a request to ', request, url);
-      this.locationLike.assign(url);
+      if (configuration.endSessionEndpoint !== undefined) {
+        const url = this.buildRequestUrl(configuration, request);
+        log('Making a request to ', request, url);
+        this.locationLike.assign(url);
+      } else {
+        this.locationLike.assign(request.redirectUri);
+      }
     });
   }
 }

--- a/src/hooks/api.ts
+++ b/src/hooks/api.ts
@@ -4,6 +4,7 @@ import {
   FetchRequestor,
   GRANT_TYPE_AUTHORIZATION_CODE,
   GRANT_TYPE_REFRESH_TOKEN,
+  RevokeTokenRequest,
   StringMap,
   TokenRequest,
   TokenResponse,
@@ -50,6 +51,20 @@ export async function performRefreshTokenRequest(
 
   const tokenHandler = new BaseTokenRequestHandler(new FetchRequestor());
   return tokenHandler.performTokenRequest(configuration, tokenRequest);
+}
+
+export async function performRevokeTokenRequest(
+  configuration: AuthorizationServiceConfiguration,
+  clientId: string,
+  token: string,
+): Promise<boolean> {
+  const tokenRequest = new RevokeTokenRequest({
+    client_id: clientId,
+    token: token,
+  });
+
+  const tokenHandler = new BaseTokenRequestHandler(new FetchRequestor());
+  return tokenHandler.performRevokeTokenRequest(configuration, tokenRequest);
 }
 
 export function performEndSessionRequest(


### PR DESCRIPTION
… configuration

Gitlab as IDP does not support the endSession Endpoint and doesn't handle it propperly.
My idea is now to just call the revoke-endpoint and return false.

This false indicates, that the app must redirect itself, as no endSession request will do that.

Not sure if this is the best idea.