### PR TITLE
✨ implement checkToken hook to manually refresh access token

### DIFF
--- a/src/hooks/Auth.ts
+++ b/src/hooks/Auth.ts
@@ -148,7 +148,6 @@ export const useAuth = ({
           const statusCode = Number.parseInt(err.message, 10);
           if (statusCode >= 400 && statusCode < 500) {
             // HTTP client error -> token is probably expired
-            console.log('Removing expired refresh token');
             setRefreshToken(undefined);
             setToken(undefined);
             setIdToken(undefined);
@@ -225,7 +224,6 @@ export const useAuth = ({
   useEffect(() => {
     AuthorizationServiceConfiguration.fetchFromIssuer(options.openIdConnectUrl, new FetchRequestor())
       .then(response => {
-        console.log('Fetched service configuration', response);
         setConfiguration(response);
       })
       .catch(err => onError(err, ErrorAction.FETCH_WELL_KNOWN));

--- a/src/hooks/mutex.ts
+++ b/src/hooks/mutex.ts
@@ -1,0 +1,24 @@
+/**
+ * Wraps the passed async function to only allow a single concurrent invocation. If a previous invocation is
+ * still executing, it will instead wait for the current invocation to finish and return the same
+ * return value.
+ * @returns the wrapped function
+ */
+export function singleEntry<T extends unknown[], R>(asyncFunc: (...args: T) => Promise<R>): (...args: T) => Promise<R> {
+  let currentInvocation: Promise<R> | undefined;
+  return async (...args: T) => {
+    if (currentInvocation) {
+      return await currentInvocation;
+    } else {
+      currentInvocation = new Promise((resolve, reject) => {
+        asyncFunc(...args)
+          .then(resolve)
+          .catch(reject)
+          .finally(() => {
+            currentInvocation = undefined;
+          });
+      });
+      return currentInvocation;
+    }
+  };
+}


### PR DESCRIPTION
On Android/IOS the `setTimeout` way of refreshing the access/id token does not work reliably if the app is sent to the background.

To work around this, this PR implements a new `checkToken` method that will manually trigger the refresh that is usually done by the timer function. 

To simplify integration in the API layer, the `checkToken` method waits for the refresh to complete, and returns the new set of tokens if a refresh was performend.